### PR TITLE
Check comment in Pull Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Known Bugs:
 - If you kill an enemy with Haggar's Suplex or Pile Driver and an Andore stomp you at the correct time, the enemy might become invincible, [check](https://www.youtube.com/watch?v=y1_6129sQOU) (bug present in the original game).
 - It is possible to kill the last boss (Belger) before he goes to the corner, which leads to a bugged animation of him falling through the window (bug present in the original game).
 - Enemies sometimes spawn with weird palletes (3rd and 4th stage).
-- Bugged sprite layers (3rd, 5th and 6th stage?).
+- Bugged sprite layers (3rd, 5th and 6th stage?)..
 <br/><br/>


### PR DESCRIPTION
Greetings, (no need for the change to the ReadMe) just sending in a bug,

In using the editor for the great Final Fight AE for CPS2, I am working on some mods.

Before modding, my original ffightaec2 rom is loading properly in Final Burn Neo in RetroArch on Android. 

But with the randomizer at https://gamehackfan.github.io/ffaee-c2/ I am getting some errors when loading the game..

Here's my use case:
1. Load and Clone ROM
2. FBNeo ROM Type
3. Randomizer Seed, Add Changes
4. Generate ROM

When loading, Final Burn Neo gives the message:
One of your romsets is missing files for THIS VERSION of FBNeo.
ff-23m.8h
ff-22m.7h

Or with no changes:
ff-23m.8h

Is the editor at https://gamehackfan.github.io/ffaee-c2/ generating the new Final Burn Neo roms correctly?